### PR TITLE
feat: send reminder api integration

### DIFF
--- a/lib/sign_well/client.rb
+++ b/lib/sign_well/client.rb
@@ -11,7 +11,7 @@ module SignWell
     def document(id, params = {})
       DocumentResource.new(self).get(id, params)
     end
-    
+
     def create_document(params)
       DocumentResource.new(self).create(params)
     end
@@ -26,6 +26,10 @@ module SignWell
 
     def delete_document(id)
       DocumentResource.new(self).delete(id)
+    end
+
+    def completed_pdf(id, params)
+      DocumentResource.new(self).completed_pdf(id, params)
     end
 
     def remind_document(id, params = {})

--- a/lib/sign_well/client.rb
+++ b/lib/sign_well/client.rb
@@ -28,8 +28,8 @@ module SignWell
       DocumentResource.new(self).delete(id)
     end
 
-    def completed_pdf(id, params)
-      DocumentResource.new(self).completed_pdf(id, params)
+    def remind_document(id, params = {})
+      DocumentResource.new(self).remind(id, params)
     end
 
     def template(id, params = {})

--- a/lib/sign_well/resources/document_resource.rb
+++ b/lib/sign_well/resources/document_resource.rb
@@ -23,5 +23,9 @@ module SignWell
     def completed_pdf(id, params)
       Response.new(get_request("documents/#{id}/completed_pdf", params).body)
     end
+
+    def remind(id, params)
+      Response.new(post_request("documents/#{id}/remind", params).body)
+    end
   end
 end

--- a/test/sign_well/resources/document_resource_test.rb
+++ b/test/sign_well/resources/document_resource_test.rb
@@ -47,7 +47,7 @@ class DocumentResourceTest < Minitest::Test
     stubs = stub_post_request("documents/#{id}/remind", response: File.read("test/fixtures/document.json"))
     client = SignWell::Client.new(x_api_key: "key", stubs: stubs)
     response = client.remind_document(id)
-    assert_equal "Created", response.to_object.status
+    assert_response_body(response)
   end
 
   def test_completed_pdf

--- a/test/sign_well/resources/document_resource_test.rb
+++ b/test/sign_well/resources/document_resource_test.rb
@@ -42,6 +42,14 @@ class DocumentResourceTest < Minitest::Test
     assert_equal 204, response.to_object.status
   end
 
+  def test_remind_document
+    id = "123"
+    stubs = stub_post_request("documents/#{id}/remind", response: File.read("test/fixtures/document.json"))
+    client = SignWell::Client.new(x_api_key: "key", stubs: stubs)
+    response = client.remind_document(id)
+    assert_equal 204, response.to_object.status
+  end
+
   def test_completed_pdf
     id = "123"
     stubs = stub_get_request("documents/#{id}/completed_pdf", response: File.read("test/fixtures/completed_pdf.json"))

--- a/test/sign_well/resources/document_resource_test.rb
+++ b/test/sign_well/resources/document_resource_test.rb
@@ -47,7 +47,7 @@ class DocumentResourceTest < Minitest::Test
     stubs = stub_post_request("documents/#{id}/remind", response: File.read("test/fixtures/document.json"))
     client = SignWell::Client.new(x_api_key: "key", stubs: stubs)
     response = client.remind_document(id)
-    assert_equal 204, response.to_object.status
+    assert_equal "Created", response.to_object.status
   end
 
   def test_completed_pdf


### PR DESCRIPTION
## Summary 📔 

#### Signwell `remind` api integration (ref: https://developers.signwell.com/reference/post_api-v1-documents-id-remind)

- A new method `remind` was added to the `DocumentResource` class.
- This method takes a `document_id` and an optional `body` hash as parameters.
- It sends a POST request to the endpoint `"documents/#{document_id}/remind"` with the `body` and returns the response body.
